### PR TITLE
make ELF detection less picky

### DIFF
--- a/src/analysis/analyze.rs
+++ b/src/analysis/analyze.rs
@@ -125,8 +125,8 @@ impl Header
     }
     fn identify(&mut self, binary: &mut [u8])->BinaryType{
     
-        let test_elf = &binary[0..7];
-        if test_elf.eq(b"\x7f\x45\x4c\x46\x02\x02\x01")
+        let test_elf = &binary[0..4];
+        if test_elf.eq(b"\x7f\x45\x4c\x46")
         {
             self.binary_type = BinaryType::ELF;
             return BinaryType::ELF;


### PR DESCRIPTION
specifying the additional 0x02 0x02 0x01 as ELF meant only 64-bit big-endian ELF matched

**cough** screenshot is from a fresh xori build on an x86_64 machine **cough**
![xori bytes](https://user-images.githubusercontent.com/4615790/43877783-963c19f2-9b50-11e8-884c-5bce77e1362c.png)
