### PR TITLE
read_int cleanup

### DIFF
--- a/src/arch/x86/analyzex86.rs
+++ b/src/arch/x86/analyzex86.rs
@@ -322,7 +322,7 @@ impl Statex86 {
         address: i64,
         value_size: usize) -> i64
     {
-        if address == 0{
+        if address == 0 {
             return 0;
         }
 

--- a/src/arch/x86/analyzex86.rs
+++ b/src/arch/x86/analyzex86.rs
@@ -10,6 +10,8 @@ use std::collections::VecDeque;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use num::{Num, NumCast};
+use num::traits::AsPrimitive;
+use std::num::Wrapping;
 use std::ops::BitOr;
 use std::ops::Bound::Included;
 
@@ -331,65 +333,32 @@ impl Statex86 {
             return 0;
         }
         let index: isize = index_check;
-        if 0 <= index && index < self.stack.len() as isize 
-        {
-            let stack_bytes : &[u8] = &self.stack;
+        if 0 <= index && index < self.stack.len() as isize {
             match value_size
             {
-                1=>{
-                    let mut temp: u8 = 0;
-                    if read_int::<u8>(
-                        &mut temp, 
-                        index as usize, 
-                        0,
-                        self.stack.len(),
-                        stack_bytes)
-                    {
-                        return (temp as i8) as i64;
-                    }
+                1 => {
+                    read_int::<i8>(index as usize, 0, &self.stack)
+                        .unwrap_or(0) as i64
                 },
-                2=>{
-                    let mut temp: u16 = 0;
-                    if read_int::<u16>(
-                        &mut temp, 
-                        index as usize, 
-                        0,
-                        self.stack.len(),
-                        stack_bytes)
-                    {
-                        return (temp as i16) as i64;
-                    }
+                2 => {
+                    read_int::<i16>(index as usize, 0, &self.stack)
+                        .unwrap_or(0) as i64
                 },
-                4=>{
-                    let mut temp: u32 = 0;
-                    if read_int::<u32>(
-                        &mut temp, 
-                        index as usize, 
-                        0,
-                        self.stack.len(),
-                        stack_bytes)
-                    {
-                        return (temp as i32) as i64;
-                    }
+                4 => {
+                    read_int::<i32>(index as usize, 0, &self.stack)
+                        .unwrap_or(0) as i64
                 },
-                8=>{
-                    let mut temp: u64 = 0;
-                    if read_int::<u64>(
-                        &mut temp, 
-                        index as usize, 
-                        0,
-                        self.stack.len(),
-                        stack_bytes)
-                    {
-                        return temp as i64;
-                    }
+                8 => {
+                    read_int::<i64>(index as usize, 0, &self.stack)
+                        .unwrap_or(0) as i64
                 },
-                _=>{}
+                _ => 0
             }
+        } else {
+            0
         }
-
-        return 0
     }
+
     pub fn stack_write(
         &mut self,
         address: u64,
@@ -454,27 +423,34 @@ pub struct MemoryManager<'a>
     pub list: Vec<MemoryBounds<'a>>,
 }
 
-fn read_int<T: Num + BitOr<Output=T> + NumCast + Copy>(
-     _byte: &mut T,
+pub fn read_int<T: Num + NumCast + Copy + 'static>(
      _offset: usize,
      _address: usize,
-     _size: usize,
-     _binary: &[u8])-> bool
+     _binary: &[u8]) -> Option<T>
+    where u64: AsPrimitive<T>
 {
-    let length = ::std::mem::size_of::<T>();
+    if let Some(start) = _offset.checked_sub(_address) {
+        // start does not underflow, good!
 
-    for offset in 0..length {
-        let mut _byte0: u8 = 0;
-        let address_offset = _offset-_address+offset;
-        
-        if address_offset >= _size{
-            return false;
+        let count_to_read = ::std::mem::size_of::<T>();
+
+        if let Some(end) = start.checked_add(count_to_read) {
+            if end <= _binary.len() {
+                // end is in bounds, also good!
+
+                let mut result: u64 = 0;
+
+                for byte_index in 0..count_to_read {
+                    result |= (_binary[start + byte_index] as u64) << (byte_index * 8);
+                }
+
+                return NumCast::from::<u64>(result)
+                    .map(|x: u64| x.as_());
+            }
         }
-        _byte0 = _binary[address_offset];
-        let new_num = (_byte0 as u64) << (offset as u64 * 8);
-        *_byte = *_byte | NumCast::from(new_num).unwrap();
-    } 
-    return true;
+    }
+
+    return None;
 }
 
 fn binary_write(
@@ -504,61 +480,28 @@ fn binary_read(
     address: usize,  
     value_size: usize,
     base_addr: usize,
-    binary: &mut [u8])->i64
+    binary: &mut [u8]) -> i64
 {
-    match value_size 
+    match value_size
     {
-        1=>{
-            let mut temp: u8 = 0;
-            if read_int::<u8>(
-                &mut temp, 
-                address as usize, 
-                base_addr,
-                binary.len(),
-                binary)
-            {
-                return (temp as i8) as i64;
-            }
+        1 => {
+            read_int::<u8>(address, base_addr, binary)
+                .unwrap_or(0) as i8 as i64
         },
-        2=>{
-            let mut temp: u16 = 0;
-            if read_int::<u16>(
-                &mut temp, 
-                address as usize, 
-                base_addr,
-                binary.len(),
-                binary)
-            {
-                return (temp as i16) as i64;
-            }
+        2 => {
+            read_int::<u16>(address, base_addr, binary)
+                .unwrap_or(0) as i16 as i64
         },
-        4=>{
-            let mut temp: u32 = 0;
-            if read_int::<u32>(
-                &mut temp, 
-                address as usize, 
-                base_addr,
-                binary.len(),
-                binary)
-            {
-                return (temp as i32) as i64;
-            }
+        4 => {
+            read_int::<u32>(address, base_addr, binary)
+                .unwrap_or(0) as i32 as i64
         },
-        8=>{
-            let mut temp: u64 = 0;
-            if read_int::<u64>(
-                &mut temp, 
-                address as usize, 
-                base_addr,
-                binary.len(),
-                binary)
-            {
-                return temp as i64;
-            }
+        8 => {
+            read_int::<u64>(address, base_addr, binary)
+                .unwrap_or(0) as i64
         },
-        _=>{}
+        _ => 0
     }
-    return 0;
 }
 
 pub fn transmute_integer_to_vec(

--- a/src/arch/x86/archx86.rs
+++ b/src/arch/x86/archx86.rs
@@ -5,8 +5,8 @@ use arch::x86::opcodex86::*;
 use arch::x86::operandx86::*;
 use arch::x86::disasmtablesx86::*;
 use arch::x86::displayx86::*;
-use std::ops::BitOr;
 use num::{Num, NumCast};
+use num::traits::AsPrimitive;
 use std::fmt::Debug;
 
 // Enums
@@ -192,7 +192,7 @@ pub struct ModRmx86
     pub base_ea_reg: u16,
     pub base_ea_base: u16,
     pub base_ea: u16,
-    pub displacement_ea: u8,
+    pub displacement_ea: EADisplacement,
     /// The displacement, used for memory operands
     pub displacement:Option<Displacementx86>,
     /// SIB state
@@ -209,7 +209,7 @@ impl Default for ModRmx86 {
             base_ea_reg: 0,
             base_ea_base: 0,
             base_ea: 0,
-            displacement_ea: 0,
+            displacement_ea: EADisplacement::Size0,
             displacement: None,
             sib: None,
         }
@@ -614,77 +614,17 @@ pub fn release_byte(_instr: &mut Instructionx86){
     _instr.cursor=_instr.cursor-1;
 }
 
-pub fn get_int_signed<T: Num + BitOr<Output=T> + NumCast + Copy>(
-    _instr: &mut Instructionx86,
-     _byte: &mut T)-> bool
+pub fn get_int<T: Num + NumCast + Copy + 'static>(
+    _instr: &mut Instructionx86) -> Option<T>
+    where u64: AsPrimitive<T>
 {
-    
-    let length = ::std::mem::size_of::<T>();  
-    disasm_debug!("get_int_signed() {:?}", length);
-    for offset in 0..length {
-        let mut _byte0: u8 = 0;
-        let address_offset = (_instr.cinfo.offset-_instr.cinfo.address) as usize;
-        let offset_size: usize = ((_instr.cursor+offset as u64)-_instr.cinfo.offset) as usize;
-        if offset_size+address_offset >= _instr.cinfo.size{
-            return false;
-        }
-        _byte0 = _instr.cinfo.code[offset_size+address_offset];
-        let new_num = (_byte0 as u64) << (offset as u64 * 8);
-        disasm_debug!("\tget_int byte {:x}", _byte0);
-        disasm_debug!("\tget_int shifted byte {:x}", new_num);
-
-        match length{
-            1=>{
-                let mut cast_byte: i8 =  NumCast::from(*_byte).unwrap();
-                cast_byte |= new_num as i8;
-                *_byte = NumCast::from(cast_byte).unwrap();
-            },
-            2=>{
-                let mut cast_byte: i16 =  NumCast::from(*_byte).unwrap();
-                cast_byte |= new_num as i16;
-                *_byte = NumCast::from(cast_byte).unwrap();
-            },
-            4=>{
-                let mut cast_byte: i32 =  NumCast::from(*_byte).unwrap();
-                cast_byte |= new_num as i32;
-                *_byte = NumCast::from(cast_byte).unwrap();
-            },
-            _=>{
-                let mut cast_byte: i64 =  NumCast::from(*_byte).unwrap();
-                cast_byte |= new_num as i64;
-                *_byte = NumCast::from(cast_byte).unwrap();
-            },
-        }
-    }   
-    _instr.cursor=_instr.cursor+length as u64;
-    return true;
+    let result = ::arch::x86::analyzex86::read_int::<T>(_instr.cursor as usize, _instr.cinfo.address as usize, &_instr.cinfo.code);
+    if result.is_some() {
+        _instr.cursor += ::std::mem::size_of::<T>() as u64;
+    }
+    return result;
 }
 
-pub fn get_int<T: Num + BitOr<Output=T> + NumCast + Copy>(
-    _instr: &mut Instructionx86,
-     _byte: &mut T)-> bool
-{
-    
-    let length = ::std::mem::size_of::<T>();  
-    disasm_debug!("get_int() {:?}", length);
-    for offset in 0..length {
-        let mut _byte0: u8 = 0;
-        let address_offset = (_instr.cinfo.offset-_instr.cinfo.address) as usize;
-        let offset_size: usize = ((_instr.cursor+offset as u64)-_instr.cinfo.offset) as usize;
-        if offset_size+address_offset >= _instr.cinfo.size{
-            return false;
-        }
-        _byte0 = _instr.cinfo.code[offset_size+address_offset];
-        let new_num = (_byte0 as u64) << (offset as u64 * 8);
-        disasm_debug!("\tget_int byte {:x}", _byte0);
-        disasm_debug!("\tget_int shifted byte {:x}", new_num);
-
-        
-        *_byte = *_byte | NumCast::from(new_num).unwrap();
-    }   
-    _instr.cursor=_instr.cursor+length as u64;
-    return true;
-}
 
 impl <'a>Instructionx86<'a>{
     pub fn new(_code: CodeInfo<'a>)->Instructionx86<'a>{

--- a/src/arch/x86/displayx86.rs
+++ b/src/arch/x86/displayx86.rs
@@ -21769,7 +21769,7 @@ pub fn build_rm_memory<T: ArchDetail>(
             {
                 match rm.base_ea{
                     0=>{
-                        if rm.displacement_ea == 0 {
+                        if rm.displacement_ea == EADisplacement::Size0 {
                             disasm_debug!("\tdisplacement_ea is 0");
                             return false; 
                         }

--- a/src/arch/x86/operandx86.rs
+++ b/src/arch/x86/operandx86.rs
@@ -847,88 +847,61 @@ fn operand_immediate(_instr: &mut Instructionx86, _size: u8) -> bool
         disasm_debug!("\talready consumed maximum immediates");
         return false;
     }
-    let mut _byte_u8: u8 = 0;
-    let mut _byte_u16: u16 = 0;
-    let mut _byte_u32: u32 = 0;
-    let mut _byte_u64: u64 = 0;
 
     let current_location = _instr.cursor - _instr.start;
     let mut size = _size;
-    if size == 0{
+    if size == 0 {
         size = _instr.size.immediate;
     } else {
         _instr.size.immediate = size;
-    }
+    };
 
-    match size{
-        1=>{
+    let imm: i64 = match size {
+        1 => {
             disasm_debug!("get_int::<u8>");
-            if !get_int::<u8>(_instr, &mut _byte_u8){ return false; }
-            if _instr.immediates.is_none(){
-                _instr.immediates = Some(Immediatex86{..Default::default()});
-            }
-            match _instr.immediates{
-                Some(ref mut im)=>{
-
-                    im.data[im.count as usize] = _byte_u8 as i64;
-                    im.offset[im.count as usize] = current_location as u8;
-                    im.count+=1
-                },
-                None=>{},
+            match get_int::<u8>(_instr) {
+                Some(value) => value as i64,
+                None => { return false; }
             }
         },
-        2=>{
+        2 => {
             disasm_debug!("get_int::<u16>");
-            if !get_int::<u16>(_instr, &mut _byte_u16){ return false; }
-            if _instr.immediates.is_none(){
-                _instr.immediates = Some(Immediatex86{..Default::default()});
-            }
-            match _instr.immediates{
-                Some(ref mut im)=>{
-
-                    im.data[im.count as usize] = _byte_u16 as i64;
-                    im.offset[im.count as usize] = current_location as u8;
-                    im.count+=1
-                },
-                None=>{},
+            match get_int::<u16>(_instr) {
+                Some(value) => value as i64,
+                None => { return false; }
             }
         },
-        4=>{
+        4 => {
             disasm_debug!("get_int::<u32>");
-            if !get_int::<u32>(_instr, &mut _byte_u32){ return false; }
-            if _instr.immediates.is_none(){
-                _instr.immediates = Some(Immediatex86{..Default::default()});
-            }
-            match _instr.immediates{
-                Some(ref mut im)=>{
-
-                    im.data[im.count as usize] = _byte_u32 as i64;
-                    im.offset[im.count as usize] = current_location as u8;
-                    im.count+=1
-                },
-                None=>{},
+            match get_int::<u32>(_instr) {
+                Some(value) => value as i64,
+                None => { return false; }
             }
         },
-        8=>{
+        8 => {
             disasm_debug!("get_int::<u64>");
-            if !get_int::<u64>(_instr, &mut _byte_u64){ return false; }
-            if _instr.immediates.is_none(){
-                _instr.immediates = Some(Immediatex86{..Default::default()});
-            }
-            match _instr.immediates{
-                Some(ref mut im)=>{
-
-                    im.data[im.count as usize] = _byte_u64 as i64;
-                    im.offset[im.count as usize] = current_location as u8;
-                    im.count+=1
-                },
-                None=>{},
+            match get_int::<u64>(_instr) {
+                Some(value) => value as i64,
+                None => { return false; }
             }
         },
-        _=>{
+        _ => {
             disasm_debug!("\tunknown size");
             return false;
         },
+    };
+
+    if _instr.immediates.is_none() {
+        _instr.immediates = Some(Immediatex86{..Default::default()});
+    }
+    match _instr.immediates {
+        Some(ref mut im) => {
+
+            im.data[im.count as usize] = imm;
+            im.offset[im.count as usize] = current_location as u8;
+            im.count += 1
+        },
+        None => {},
     }
 
     return true;
@@ -1330,7 +1303,7 @@ pub fn operand_read(_instr: &mut Instructionx86) -> bool
                 }
                 //AVX512 compressed displacement scaling factor
                 if DISASMX86_OPERANDSETS[spec][index].encoding != OperandEncodingx86::ENCODINGREG &&
-                as_ref!(_instr, mod_rm, displacement_ea) == EADisplacement::Size8 as u8 {
+                as_ref!(_instr, mod_rm, displacement_ea) == EADisplacement::Size8 {
                     match _instr.mod_rm {
                         Some(ref mut mod_rm)=>{
                             match mod_rm.displacement{

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -169,8 +169,12 @@ impl Xori
                     instructions = Instruction::new();
                     instructions.address = _address as u64;
                     instructions.offset = offset;
-                    ret = disasmx86(_code, _size, &mut length, offset as u64, &mut instructions, &self.mode);
-                    if ret{
+                    ret = if let Some(x86_mode) = Modex86::from_mode(&self.mode) {
+                        disasmx86(_code, _size, &mut length, offset as u64, &mut instructions, x86_mode)
+                    } else {
+                        false
+                    };
+                    if ret {
                         _next_offset = length;
                         length = 0;
                     } else {

--- a/src/test.rs
+++ b/src/test.rs
@@ -361,3 +361,15 @@ fn flirt_up()
     sig_analyzer.load_flirts(&String::new());
     sig_analyzer.flirt_match(&bytes);
 }
+
+#[test]
+fn test_read_int() {
+    use arch::x86::analyzex86::read_int;
+    let buf = [0x11, 0x22, 0x33, 0x44, 0xff, 0xff, 0xff, 0xff];
+
+    assert!(read_int::<u8>(0, 0, &buf) == Some(0x11));
+    assert!(read_int::<u16>(0, 0, &buf) == Some(0x2211));
+    assert!(read_int::<u32>(0, 0, &buf) == Some(0x44332211));
+    assert!(read_int::<u64>(0, 0, &buf) == Some(0xffffffff44332211));
+    assert!(read_int::<i16>(6, 0, &buf) == Some(-1i16));
+}


### PR DESCRIPTION
These changes do *not* change functionality (at least with a very "rigorous" test by comparing output from before and after of a `xori.exe` binary) - the intent here is more to remove duplicate code, rustify other code, remove unneeded parameters, etc.

I'll put a handful of comments in-line on things of note. I have no particular attachments to any of this, so if anything was the way it was for intentional architectural or style reasons, 'sall good