### PR TITLE
Update api-consumer.jsx

### DIFF
--- a/gui/src/services/api-consumer/api-consumer.jsx
+++ b/gui/src/services/api-consumer/api-consumer.jsx
@@ -4,7 +4,7 @@ export default function uploadFileToDisassemble(file) {
   let formData = new FormData();
   formData.append('fileToDisassemble', file);
 
-  return fetch("http://localhost:5000/disassemble-file", {
+  return fetch("http://"+window.location.hostname+":5000/disassemble-file", {
     method: "POST",
     body: formData
   }).then((response) => {


### PR DESCRIPTION
While the webUI is accessible via the network hardcoding 'localhost' returns errors when uploading from another machine. Substituting "localhost' with 'window.location.hostname' dynamically changes the POST URL path to adjust and remain functional from other machines on the Network. In my case Xori can now be used on a centralized server that is shared between team members.