### PR TITLE
Fix build warnings produced by rustc 1.41.1

### DIFF
--- a/src/analysis/data_analyzer.rs
+++ b/src/analysis/data_analyzer.rs
@@ -169,7 +169,7 @@ pub fn analyze_datax86(
                     _=>{},
                 }
                 instructions.size = address_size;
-                let mut valid_instr = InstructionInfo
+                let valid_instr = InstructionInfo
                   {
                     instr: instructions,
                     detail: Vec::new(),

--- a/src/analysis/signature_analysis.rs
+++ b/src/analysis/signature_analysis.rs
@@ -223,7 +223,7 @@ impl SigAnalyzer
                         }
                     }
                 }
-                regex = regex.trim_right_matches("|").to_string();
+                regex = regex.trim_end_matches("|").to_string();
                 self.full_signatures_regex = Regex::new(&regex).unwrap();
             },
             _=>{},
@@ -251,7 +251,7 @@ impl SigAnalyzer
                         })).as_str()).unwrap();
 
                         let marked_offset = &v[4];
-                        let offset = usize::from_str_radix(marked_offset.trim_left_matches(':').trim_right_matches('@'), 16).unwrap(); // has special trailing chars and starts with :
+                        let offset = usize::from_str_radix(marked_offset.trim_start_matches(':').trim_end_matches('@'), 16).unwrap(); // has special trailing chars and starts with :
                         let mut my_refs = vec![];
                         if v.len() > 6 {
                             for rawref in v[6..].iter().collect::<Vec<_>>().chunks(2) { // keep first ref
@@ -261,8 +261,8 @@ impl SigAnalyzer
                                 //16).unwrap() > 0x8000 { continue; } // bold play to try and keep
                                 //within bounds // this may be necessary again to make sure we
                                 //don't step over the bounds of the binary
-                                let mut flirtref = FlirtRef {
-                                    offset: usize::from_str_radix((rawref[0]).trim_left_matches('^').trim_left_matches(':').trim_right_matches('@'), 16).unwrap(),
+                                let flirtref = FlirtRef {
+                                    offset: usize::from_str_radix((rawref[0]).trim_start_matches('^').trim_start_matches(':').trim_end_matches('@'), 16).unwrap(),
                                     refkind: match rawref[0].chars().next().unwrap() {
                                         ':' => RefKind::Local,
                                         _ => RefKind::Reference,
@@ -329,7 +329,7 @@ impl SigAnalyzer
                 for (ind_fm, fm) in fmvec.iter().enumerate() {
                     for sigref in &self.flirts.get(&fm.name).unwrap().references {
                         if known.contains_key(&(fm.offset + sigref.offset)) {
-                            let mut xs = _superunknown.get_mut(&(fm.offset)).unwrap();
+                            let xs = _superunknown.get_mut(&(fm.offset)).unwrap();
                             if xs[ind_fm].refcount == 0 {
                                 known.insert(fm.offset,fm.clone());
                                 xs.remove(ind_fm);
@@ -385,7 +385,7 @@ impl SigAnalyzer
                         regex += &format!("{}|", sig);
                     }
                 }
-                regex = regex.trim_right_matches("|").to_string();
+                regex = regex.trim_end_matches("|").to_string();
                 let re = Regex::new(&regex).unwrap();
                 for cap in re.captures_iter(&bytes) {
                     match cap.name(sig_name) {

--- a/src/arch/x86/displayx86.rs
+++ b/src/arch/x86/displayx86.rs
@@ -21493,10 +21493,10 @@ pub fn build_immediates<T: ArchDetail>(
             if _immediate <= 0xf {
                 match opcode{
                     //CMPPD, CMPPS, CMPSD, CMPSS
-                    550...553 | //CMPPD,
-                    554...557 | //CMPPS,
-                    559...562 | //CMPSD
-                    565...568 // CMPSS
+                    550..=553 | //CMPPD,
+                    554..=557 | //CMPPS,
+                    559..=562 | //CMPSD
+                    565..=568 // CMPSS
                     =>set_sse_cc(_detail, _immediate),
                     _=>{},
                 }
@@ -21650,7 +21650,7 @@ pub fn build_rm_register<T: ArchDetail>(
             }
             match rm.base_ea{
                 r if r == Registersx86::NoRegister as u16=>{ return false; },
-                1...260=>{                    
+                1..=260=>{                    
                     match rm.kind {
                         RegType::AllRegisters=>{
                             let offset = rm.base_ea;
@@ -21700,7 +21700,7 @@ pub fn build_rm_memory<T: ArchDetail>(
                     Some(ref sib)=>{
                         if sib.sib_base != Registersx86::NoRegister as u8{
                             match sib.sib_base{
-                                1...211=>{ // All Registers
+                                1..=211=>{ // All Registers
                                     _base_reg = AllRegisters::translate(sib.sib_base);                                    
                                 }
                                 _=>{ 

--- a/src/arch/x86/emulatex86.rs
+++ b/src/arch/x86/emulatex86.rs
@@ -733,7 +733,7 @@ fn mulx86(signed: bool, size: usize, value2: i64, _state: &mut Statex86)
         },
         2=>{
             let reg = _state.cpu.get_register(&(Registersx86::AX as u8), 0);
-            let (mut temp, _is_overflow) = match signed
+            let (temp, _is_overflow) = match signed
             {
                 true=>{
                     let (temp, _of) = (reg as i32).overflowing_mul(value2 as i32);
@@ -761,7 +761,7 @@ fn mulx86(signed: bool, size: usize, value2: i64, _state: &mut Statex86)
         },
         4=>{
             let reg = _state.cpu.get_register(&(Registersx86::EAX as u8), 0);
-            let (mut temp, _is_overflow) = match signed
+            let (temp, _is_overflow) = match signed
             {
                 true=>{
                     let (temp, _of) = (reg as i64).overflowing_mul(value2 as i64);
@@ -790,7 +790,7 @@ fn mulx86(signed: bool, size: usize, value2: i64, _state: &mut Statex86)
         _=>{
             let reg = _state.cpu.get_register(&(Registersx86::RAX as u8), 0);
 
-            let (mut temp, _is_overflow) = match signed
+            let (temp, _is_overflow) = match signed
             {
                 true=>{
                     let (temp, _of) = (reg as i128).overflowing_mul(value2 as i128);
@@ -1632,7 +1632,7 @@ fn check_binary_arithmetic_instructions(
 
             };
             // TODO: fix this
-            let mut auxiliary = FlagDefined::Unset;
+            let auxiliary = FlagDefined::Unset;
             
             // set first operand
             match _state.cpu.address_size{
@@ -1998,7 +1998,7 @@ fn check_shift_rotate_instructions(
                     ((v as i8) as i64, FlagDefined::Unset)
                 },
                 2=>{
-                    let (v, mut ov) = (value1 as i16).overflowing_shr(value2 as u32);
+                    let (v, ov) = (value1 as i16).overflowing_shr(value2 as u32);
                     let mut overflow = FlagDefined::Unset;
                     if ov{
                         overflow = FlagDefined::Set;
@@ -2009,7 +2009,7 @@ fn check_shift_rotate_instructions(
                     ((v as i16) as i64, overflow) 
                 },
                 4=>{
-                    let (v, mut ov) = (value1 as i32).overflowing_shr(value2 as u32);
+                    let (v, ov) = (value1 as i32).overflowing_shr(value2 as u32);
                     let mut overflow = FlagDefined::Unset;
                     if ov{
                         overflow = FlagDefined::Set;
@@ -2186,7 +2186,7 @@ fn check_shift_rotate_instructions(
                     ((v as i8) as i64, FlagDefined::Unset)
                 },
                 2=>{
-                    let (v, mut ov) = (value1 as u16).overflowing_shr(value2 as u32);
+                    let (v, ov) = (value1 as u16).overflowing_shr(value2 as u32);
                     let mut overflow = FlagDefined::Unset;
                     if ov{
                         overflow = FlagDefined::Set;
@@ -2197,7 +2197,7 @@ fn check_shift_rotate_instructions(
                     ((v as i16) as i64, overflow) 
                 },
                 4=>{
-                    let (v, mut ov) = (value1 as u32).overflowing_shr(value2 as u32);
+                    let (v, ov) = (value1 as u32).overflowing_shr(value2 as u32);
                     let mut overflow = FlagDefined::Unset;
                     if ov{
                         overflow = FlagDefined::Set;

--- a/src/arch/x86/prefixx86.rs
+++ b/src/arch/x86/prefixx86.rs
@@ -73,7 +73,7 @@ fn prefix_check(
     disasm_debug!("prefix_check(byte: {:?})", byte);
     match *byte
     {
-        0x40...0x4f => match *mode{ Modex86::Mode64 => return true, _=> return false, }, /* REX */
+        0x40..=0x4f => match *mode{ Modex86::Mode64 => return true, _=> return false, }, /* REX */
         0x26 => return true, /* ES */
         0x2e => return true, /* CS */
         0x36 => return true, /* SS */
@@ -195,7 +195,7 @@ fn prefix_populate_states(
     disasm_debug!("prefix_populate_states(byte: {:x})", *byte);
     match *byte
     {
-        0x40...0x4f => match _instr.mode{ /* REX */
+        0x40..=0x4f => match _instr.mode{ /* REX */
                 Modex86::Mode64 => {
                     let flag = PrefixFlagsx86::Rex as u32;
                     let mask = PrefixMaskx86::Rex as usize;


### PR DESCRIPTION
These changes fix the following warnings:

```
warning: `...` range patterns are deprecated
  --> src/arch/x86/prefixx86.rs:76:13
--
warning: `...` range patterns are deprecated
   --> src/arch/x86/prefixx86.rs:198:13
--
warning: `...` range patterns are deprecated
     --> src/arch/x86/displayx86.rs:21496:24
--
warning: `...` range patterns are deprecated
     --> src/arch/x86/displayx86.rs:21497:24
--
warning: `...` range patterns are deprecated
     --> src/arch/x86/displayx86.rs:21498:24
--
warning: `...` range patterns are deprecated
     --> src/arch/x86/displayx86.rs:21499:24
--
warning: `...` range patterns are deprecated
     --> src/arch/x86/displayx86.rs:21653:18
--
warning: `...` range patterns are deprecated
     --> src/arch/x86/displayx86.rs:21703:34
--
warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`
   --> src/analysis/signature_analysis.rs:226:31
--
warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
   --> src/analysis/signature_analysis.rs:254:74
--
warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`
   --> src/analysis/signature_analysis.rs:254:97
--
warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
   --> src/analysis/signature_analysis.rs:265:79
--
warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
   --> src/analysis/signature_analysis.rs:265:102
--
warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`
   --> src/analysis/signature_analysis.rs:265:125
--
warning: use of deprecated item 'core::str::<impl str>::trim_right_matches': superseded by `trim_end_matches`
   --> src/analysis/signature_analysis.rs:388:31
--
warning: variable does not need to be mutable
   --> src/arch/x86/emulatex86.rs:736:18
--
warning: variable does not need to be mutable
   --> src/arch/x86/emulatex86.rs:764:18
--
warning: variable does not need to be mutable
   --> src/arch/x86/emulatex86.rs:793:18
--
warning: variable does not need to be mutable
    --> src/arch/x86/emulatex86.rs:1635:17
--
warning: variable does not need to be mutable
    --> src/arch/x86/emulatex86.rs:2001:29
--
warning: variable does not need to be mutable
    --> src/arch/x86/emulatex86.rs:2012:29
--
warning: variable does not need to be mutable
    --> src/arch/x86/emulatex86.rs:2189:29
--
warning: variable does not need to be mutable
    --> src/arch/x86/emulatex86.rs:2200:29
--
warning: variable does not need to be mutable
   --> src/analysis/data_analyzer.rs:172:21
--
warning: variable does not need to be mutable
   --> src/analysis/signature_analysis.rs:264:37
--
warning: variable does not need to be mutable
   --> src/analysis/signature_analysis.rs:332:33
```