### PR TITLE
Update deps to current versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,23 +7,23 @@ authors = [ "amanda@endgame.com" ]
 debug = true
 
 [dependencies]
-nom = "4.0.0-beta2"
-num = "0.1"
-colored = "1.6.0"
-memmap = "0.6.2"
-serde_json = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
-argparse = "0.2.1"
-bincode = "1.0.0"
+nom = "4.2.3"
+num = "0.2.1"
+colored = "1.9.3"
+memmap = "0.7.0"
+serde_json = "1.0.48"
+serde = "1.0.105"
+serde_derive = "1.0.105"
+argparse = "0.2.2"
+bincode = "1.2.1"
 encoding = "0.2.33"
 reqwest = "0.9.24"
-url = "1.7.0"
-pdb = "0.2.0"
-base64 = "0.9.1"
-uuid = { version = "0.6", features = ["v4"] }
-regex = "1"
-itertools = "0.7.8"
-glob = "0.2"
-crc = "^1.0.0"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
+url = "1.7.2"
+pdb = "0.6.0"
+base64 = "0.12.0"
+uuid = { version = "0.8.1", features = ["v4"] }
+regex = "1.3.5"
+itertools = "0.9.0"
+glob = "0.3.0"
+crc = "1.8.1"
+flate2 = { version = "1.0.14", features = ["zlib"], default-features = false }


### PR DESCRIPTION
This PR updates the dependencies for xori to their most recent versions.

The API has changed on a few dependencies so I have not updated these yet.

```
$ cargo outdated -d1
Name     Project  Compat  Latest  Kind    Platform
----     -------  ------  ------  ----    --------
nom      4.2.3    ---     5.1.1   Normal  ---
reqwest  0.9.24   ---     0.10.4  Normal  ---
url      1.7.2    ---     2.1.1   Normal  ---
```