### PR TITLE
a band-aid for a rapidly changing API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "amanda@endgame.com" ]
 debug = true
 
 [dependencies]
-nom = "4.2.3"
+nom = "5.1.1"
 num = "0.2.1"
 colored = "1.9.3"
 memmap = "0.7.0"

--- a/src/bin/peinfo.rs
+++ b/src/bin/peinfo.rs
@@ -14,8 +14,9 @@ use xori::analysis::formats::pe::{dos_header, dos_stub, image_import_by_name,
                                   ImageDataIndex, ImageOptionalHeaderKind, import_address_table32,
                                   import_address_table64, import_lookup_table32,
                                   import_lookup_table64};
-use nom::{ErrorKind, HexDisplay, IResult, InputLength, Needed, Offset, be_u8, le_u16, le_u32,
-          le_u64, le_u8};
+use nom::{HexDisplay, IResult, InputLength, Needed, Offset};
+use nom::error::ErrorKind;
+use nom::number::complete::{be_u8, le_u64, le_u32, le_u16, le_u8};
 extern crate serde;
 extern crate serde_json;
 

--- a/src/bin/pesymbols.rs
+++ b/src/bin/pesymbols.rs
@@ -9,7 +9,7 @@ extern crate url;
 extern crate pdb;
 #[macro_use]
 extern crate nom;
-use nom::{be_u64, le_u32, le_u16};
+use nom::number::complete::{be_u64, le_u32, le_u16};
 extern crate xori;
 use xori::configuration::*;
 use xori::analysis::formats::pe::*;
@@ -299,7 +299,7 @@ fn get_guid(path: &Path) -> PdbDir
         .expect("failed to open the file");
     let mmap = unsafe { Mmap::map(&file)
         .expect("failed to map the file") };
-    named!(find_dir, take_until_and_consume!("RSDS"));
+    named!(find_dir, take_until!("RSDS"));
     named!(guid<&[u8], (u32, u16, u16, u64, u32) >,
     /* todo name these... there is a from MS generator hiding
     in this PR if we want to name the chunks
@@ -314,7 +314,7 @@ fn get_guid(path: &Path) -> PdbDir
     );
 
     named!(pdb_path<&[u8], &[u8]>,
-           take_until_and_consume!("\0"));
+           take_until!("\0"));
     let res = find_dir(&mmap);
     let guid_res;
     match res {


### PR DESCRIPTION
This wraps a call returning a fixed size vector with a conversion to a fixed size array, since nom dropped a macro that returned a fixed size array.

Also some other fixes to be 5.1.1 compatible.