### PR TITLE
Fix warning for extra semicolon

### DIFF
--- a/examples/dump_functions.rs
+++ b/examples/dump_functions.rs
@@ -268,7 +268,7 @@ fn main()
 {
     let mut functions: String = String::new();
     let mut disassembly: String = String::new();
-    let mut function_address: String = String::new();;
+    let mut function_address: String = String::new();
     let mut show: bool = false;
 
     {


### PR DESCRIPTION
```
warning: unnecessary trailing semicolon
   --> examples/dump_functions.rs:271:54
    |
271 |     let mut function_address: String = String::new();;
    |                                                      ^ help: remove this semicolon
    |
    = note: `#[warn(redundant_semicolon)]` on by default
```